### PR TITLE
fix: exclude test files and internal dirs from npm tarball

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+dist/__tests__/

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "bin": {
     "oxori": "./dist/cli.js"
   },
+  "files": [
+    "dist",
+    "README.md"
+  ],
   "scripts": {
     "build": "tsc",
     "test": "vitest run --passWithNoTests",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,5 +13,5 @@
     "sourceMap": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/__tests__"]
 }


### PR DESCRIPTION
Problems found in npm publish:
1. .copilot/, .squad/ and all project dirs were published to npm
2. dist/__tests__/ compiled test files were included in tarball

Fixes:
- package.json: add 'files' whitelist (dist/, README.md only)
- tsconfig.json: exclude src/__tests__ from compilation so tests don't appear in dist/ at all (vitest uses its own transform)
- .npmignore: kept for belt-and-suspenders

Tarball now: LICENSE + README.md + dist/ engine/commands only
Size: ~25kB packed (was bloated with squad/copilot internals)